### PR TITLE
Add gemfiles so we can bundle webrick gem into Docker app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    webrick (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  webrick
+
+BUNDLED WITH
+   2.1.4


### PR DESCRIPTION
I'm not sure if my local `ruby` has `webrick` globally installed, but it somehow worked without a Gemfile. In order to support this in docker we need to bundle `webrick` in, which requires a Gemfile.

Signed-off-by: Clement Ng <clementdng@gmail.com>