### PR TITLE
Set ruby version to ruby:2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:2.7
 
 RUN bundle config --global frozen 1
 


### PR DESCRIPTION
This is a best practice, since `ruby:latest` can change. Tested that `make` and `make test` still work.

Signed-off-by: Clement Ng <clementdng@gmail.com>