### PR TITLE
Removing public field from service def

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ publish-service:
 	    SERVICE_NAME="$(SERVICE_NAME)" \
 	    VERSION="$(VERSION)"\
 	    SERVICE_CONTAINER="$(DOCKERHUB_ID)/$(SERVICE_NAME):$(VERSION)" \
-	    hzn exchange service publish -O $(CONTAINER_CREDS) -P -f horizon/service.definition.json
+	    hzn exchange service publish -O $(CONTAINER_CREDS) -P --public=true -f horizon/service.definition.json
 
 publish-pattern:
 	@ARCH=$(ARCH) \

--- a/service.json
+++ b/service.json
@@ -4,7 +4,6 @@
   "url": "$SERVICE_NAME",
   "version": "$SERVICE_VERSION",
   "arch": "$ARCH",
-  "public": true,
   "sharable": "singleton",
   "requiredServices": [],
   "userInput": [],


### PR DESCRIPTION
There was a [commit in the examples repo](https://github.com/open-horizon/examples/commit/728c479e7c4acf757bbdd37415b855e228312d89) to move the `public` field from all service definitions and allow it to be set by the `hzn` CLI instead. This updates this example to match that format.

Tested that modified Makefile target still works.

Signed-off-by: Clement Ng <clementdng@gmail.com>