### PR TITLE
Make base dockerfile image alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:2.7-alpine
 
 RUN bundle config --global frozen 1
 


### PR DESCRIPTION
This reduces docker image size to 61.8 MB.

Signed-off-by: Clement Ng <clementdng@gmail.com>